### PR TITLE
Volume related enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,16 +88,11 @@ ReceiverVolume.prototype.setPowerOn = function(powerOn, callback) {
 
 ReceiverVolume.prototype.setBrightness = function(level, callback) {
 
-    var newVolume = level;
-
-    if(level > this.maxVolume){
-        //enforce maximum volume
-        newVolume = this.maxVolume;
-        this.log('Volume %s capped to max volume %s on %s', level, this.maxVolume, this.zoneName);
-    }
+    var maxVolume = this.maxVolume * 80.0 / 100.0;
+    var newVolume = maxVolume * level / 100.0;
 
     //convert volume percentage to relative volume
-    var relativeVolume = (newVolume - 80).toFixed(1);
+    var relativeVolume = (2 * (newVolume - 80)).toFixed(0) / 2.0;
 
     //cap between -80 and 0
     relativeVolume = Math.max(-80.0, Math.min(0.0, relativeVolume));

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ ReceiverVolume.prototype.setBrightness = function(level, callback) {
 
 ReceiverVolume.prototype.getBrightness = function(callback) {
     this.getStatus(function(status) {
-        var volume = parseInt(status.MasterVolume[0].value[0]) + 80;
+        var volume = -status.MasterVolume[0].value[0] / 80.0 * 100.0;
         callback(null, volume);
     }.bind(this));
 }


### PR DESCRIPTION
Hi,

I'm using a DENON AVR-2113. I have no experience with other Denon or Marantz receivers, but I would suggest the following changes, which, imho, improve the usability.

First, instead of capping the volume, mapping the percentage value from homebridge/HomeKit to the maxVolume in the config makes for a more intuitive behavior, as the volume doesn't just stop increasing when moving past, say, 50%.

Second, and this may be Denon-specific, when sending the volume to the receiver, I round it to .0 or .5 values, as other decimal values (like -29.1dB) fail. At least my Denon model, strictly only accepts values with .0 or .5dB.