### PR TITLE
Fixed null error in getPowerOn

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ ReceiverVolume.prototype.getPowerOn = function(callback) {
         this.getStatus(function(status) {
             var powerState = status ? (status.Power[0].value[0] === "ON" ? 1 : 0) : 0;
             this.log("Receiver %s Volume power state is %s", this.zoneName, powerState);
-            callback(null, powerState);           
+            callback(null, powerState);
         }.bind(this));
     } else if (this.controlMute) {
         this.getStatus(function(status) {

--- a/index.js
+++ b/index.js
@@ -70,13 +70,13 @@ ReceiverVolume.prototype.setControl = function (control, command, callback) {
 ReceiverVolume.prototype.getPowerOn = function(callback) {
     if (this.controlPower) {
         this.getStatus(function(status) {
-            var powerState = status.Power[0].value[0] === "ON" ? 1 : 0;
+            var powerState = status ? (status.Power[0].value[0] === "ON" ? 1 : 0) : 0;
             this.log("Receiver %s Volume power state is %s", this.zoneName, powerState);
-            callback(null, powerState);
+            callback(null, powerState);           
         }.bind(this));
     } else if (this.controlMute) {
         this.getStatus(function(status) {
-            var powerState = status.Mute[0].value[0] === "on" ? 0 : 1;
+            var powerState = status ? (status.Mute[0].value[0] === "on" ? 0 : 1) : 0;
             this.log("Receiver %s Volume state is %s", this.zoneName, powerState);
             callback(null, powerState);
         }.bind(this));


### PR DESCRIPTION
This fixes the error below, which caused homebridge to crash for me.
The error occurs when attempting to get powerState on a receiver that doesn't have power, which happens quite a lot if you, like me, have your receiver on a smartplug.

<pre>
Unable to get receiver status
/usr/lib/node_modules/homebridge-marantz-volume/index.js:73
            var powerState = status.Power[0].value[0] === "ON" ? 1 : 0;
                                   ^

TypeError: Cannot read property 'Power' of null
    at ReceiverVolume.<anonymous> (/usr/lib/node_modules/homebridge-marantz-volume/index.js:73:36)
    at ReceiverVolume.<anonymous> (/usr/lib/node_modules/homebridge-marantz-volume/index.js:54:13)
    at self.callback (/usr/lib/node_modules/homebridge-marantz-volume/node_modules/request/request.js:188:22)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at Request.onRequestError (/usr/lib/node_modules/homebridge-marantz-volume/node_modules/request/request.js:884:8)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at Socket.socketErrorListener (_http_client.js:310:9)
    at emitOne (events.js:96:13)
</pre>